### PR TITLE
Mixed C# with rust types when handling idl type 'bytes'.

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -1,22 +1,22 @@
 <Project DefaultTargets="Build"
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
-		<Product>Solnet</Product>
-		<Version>0.2.4</Version>
-		<Copyright>Copyright 2022 &#169; Solnet</Copyright>
-		<Authors>blockmountain</Authors>
-		<PublisherName>blockmountain</PublisherName>
-		<RepositoryUrl>https://github.com/bmresearch/Solnet.Anchor</RepositoryUrl>
-		<LangVersion>latest</LangVersion>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageIcon>icon.png</PackageIcon>
-		<PackageDescription>Solnet.Anchor is a set of tools to integrate with Solana Anchor programs.</PackageDescription>
-		<PackageTags>solana;solnet;sol;net6;spl;anchor</PackageTags>
-		<PackageReleaseNotes>https://github.com/bmresearch/Solnet.Anchor/releases</PackageReleaseNotes>
-		<RepositoryType>git</RepositoryType>
-	</PropertyGroup>
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <Product>Solnet</Product>
+        <Version>0.2.5</Version>
+        <Copyright>Copyright 2022 &#169; Solnet</Copyright>
+        <Authors>blockmountain</Authors>
+        <PublisherName>blockmountain</PublisherName>
+        <RepositoryUrl>https://github.com/bmresearch/Solnet.Anchor</RepositoryUrl>
+        <LangVersion>latest</LangVersion>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageDescription>Solnet.Anchor is a set of tools to integrate with Solana Anchor programs.</PackageDescription>
+        <PackageTags>solana;solnet;sol;net6;spl;anchor</PackageTags>
+        <PackageReleaseNotes>https://github.com/bmresearch/Solnet.Anchor/releases</PackageReleaseNotes>
+        <RepositoryType>git</RepositoryType>
+    </PropertyGroup>
 
-	<ItemGroup Label="PackageIcon">
-		<None Include="$(MSBuildThisFileDirectory)/assets/icon.png" Pack="true" Visible="false" PackagePath=""/>
-	</ItemGroup>
+    <ItemGroup Label="PackageIcon">
+        <None Include="$(MSBuildThisFileDirectory)/assets/icon.png" Pack="true" Visible="false" PackagePath=""/>
+    </ItemGroup>
 </Project>

--- a/Solnet.Anchor/ClientGenerator.cs
+++ b/Solnet.Anchor/ClientGenerator.cs
@@ -724,13 +724,13 @@ namespace Solnet.Anchor
                         && definedTypes.FirstOrDefault(x => x.Name == d.TypeName) is EnumIdlTypeDefinition e 
                         && e.IsPureEnum()))
                 {
-                conditionBody.AddRange(GenerateArgSerializationSyntaxList(
-                    definedTypes,
-                    optionalType.ValuesType,
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        identifierNameSyntax,
-                        IdentifierName("Value"))));
+                    conditionBody.AddRange(GenerateArgSerializationSyntaxList(
+                        definedTypes,
+                        optionalType.ValuesType,
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            identifierNameSyntax,
+                            IdentifierName("Value"))));
                 }
                 else
                 {
@@ -1647,7 +1647,7 @@ namespace Solnet.Anchor
                 IdlPublicKey => IdentifierName("PublicKey"),
                 IdlString => PredefinedType(Token(SyntaxKind.StringKeyword)),
                 IdlValueType v => PredefinedType(Token(GetTokenForValueType(v))),
-                _ => throw new Exception("huh wat")
+                _ => throw new Exception("Unexpected type.")
             };
 
         private SyntaxKind GetTokenForValueType(IdlValueType idlValueType)
@@ -1661,7 +1661,8 @@ namespace Solnet.Anchor
                 "i32" => SyntaxKind.IntKeyword,
                 "u64" => SyntaxKind.ULongKeyword,
                 "i64" => SyntaxKind.LongKeyword,
-                _ => SyntaxKind.BoolKeyword
+                "bool" => SyntaxKind.BoolKeyword,
+                _ => throw new Exception("Unexpected type.")
             };
 
         private List<MemberDeclarationSyntax> GenerateAccountDiscriminator(StructIdlTypeDefinition structIdl)

--- a/Solnet.Anchor/Converters/IIdlTypeConverter.cs
+++ b/Solnet.Anchor/Converters/IIdlTypeConverter.cs
@@ -23,7 +23,7 @@ namespace Solnet.Anchor.Converters
                 {
                     "string" => new IdlString(),
                     "publicKey" => new IdlPublicKey(),
-                    "bytes" => new IdlArray() { ValuesType = new IdlValueType() { TypeName = "byte" } },
+                    "bytes" => new IdlArray() { ValuesType = new IdlValueType() { TypeName = "u8" } },
                     "u128" or "i128" => new IdlBigInt() { TypeName = typeName },
                     _ => new IdlValueType() { TypeName = typeName }
                 };


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready/Hold | Feature/Bug/Tooling/Refactor/Hotfix | Yes/No | [Link](<Issue link here>) |

## Problem

Vec<u8> is generated as bool[]


## Solution

Fixed mixed types when handling IDL type 'bytes'.