### PR TITLE
Missing account checks on client creation.

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solnet</Product>
-        <Version>0.2.6</Version>
+        <Version>0.2.7</Version>
         <Copyright>Copyright 2022 &#169; Solnet</Copyright>
         <Authors>blockmountain</Authors>
         <PublisherName>blockmountain</PublisherName>

--- a/Solnet.Anchor/ClientGenerator.cs
+++ b/Solnet.Anchor/ClientGenerator.cs
@@ -57,15 +57,15 @@ namespace Solnet.Anchor
         {
             List<MemberDeclarationSyntax> members = new();
 
-            if (idl.Accounts != null && idl.Accounts.Length > 0)
+            if (idl.Accounts is { Length: > 0 })
                 members.Add(GenerateAccountsSyntaxTree(idl));
 
             members.Add(GenerateErrorsSyntaxTree(idl));
 
-            if (idl.Events != null && idl.Events.Length > 0)
+            if (idl.Events is { Length: > 0 })
                 members.Add(GenerateEventsSyntaxTree(idl));
 
-            if (idl.Types != null && idl.Types.Length > 0)
+            if (idl.Types is { Length: > 0 })
                 members.Add(GenerateTypesSyntaxTree(idl));
 
             members.Add(GenerateClientSyntaxTree(idl));
@@ -898,12 +898,14 @@ namespace Solnet.Anchor
 
             var className = idl.Name.ToPascalCase() + "Client";
 
-            //clientMembers.AddRange(GenerateFields());
             clientMembers.Add(GenerateConstructor(idl, className));
-            //clientMembers.Add(GenerateParseAccount());
-            clientMembers.AddRange(GenerateGetAccounts(idl));
-            clientMembers.AddRange(GenerateGetAccount(idl));
-            clientMembers.AddRange(GenerateSubscribeAccount(idl));
+            
+            if (idl.Accounts is { Length: > 0 })
+            {
+                clientMembers.AddRange(GenerateGetAccounts(idl));
+                clientMembers.AddRange(GenerateGetAccount(idl));
+                clientMembers.AddRange(GenerateSubscribeAccount(idl));
+            }
 
             clientMembers.AddRange(GenerateInstructionBuilderMethods(idl));
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | Closes #18  |

## Problem

Code generation tool crashes when there are no accounts in the idl.


## Solution

Added extra nullchecks on client creation.
