### PR TITLE
Tiny bug patch - Fixed null exception in error map

### DIFF
--- a/Solnet.Anchor/ClientGenerator.cs
+++ b/Solnet.Anchor/ClientGenerator.cs
@@ -936,6 +936,9 @@ namespace Solnet.Anchor
             {
                 foreach (var val in idl.Errors)
                 {
+                    string error_msg = string.Empty;
+                    if(val.Msg != null)
+                        error_msg = val.Msg;
                     var errValue = InitializerExpression(
                         SyntaxKind.ComplexElementInitializerExpression,
                         SeparatedList<ExpressionSyntax>(
@@ -959,7 +962,7 @@ namespace Solnet.Anchor
                                         Argument(
                                             LiteralExpression(
                                                 SyntaxKind.StringLiteralExpression,
-                                                Literal(val.Msg)))})), default)}));
+                                                Literal(error_msg)))})), default)}));
                     syntaxNodeOrTokens = syntaxNodeOrTokens.Add(errValue);
                     syntaxNodeOrTokens = syntaxNodeOrTokens.Add(Token(SyntaxKind.CommaToken));
                 }


### PR DESCRIPTION
Issue:
When attempting to generate the candy machine core program one error msg had an empty string and returned null preventing the code from being generated 
Solution:
Handled the null exception by defaulting the error msg as an empty string and only utilizing the val.Msg if it was not null