### PR TITLE
Bypass "docs" in anchor idl during code generation

### DIFF
--- a/Solnet.Anchor/Converters/IIdlTypeDefinitionTyConverter.cs
+++ b/Solnet.Anchor/Converters/IIdlTypeDefinitionTyConverter.cs
@@ -33,7 +33,30 @@ namespace Solnet.Anchor.Converters
                 if (reader.TokenType != JsonTokenType.String) throw new JsonException("Unexpected error value.");
 
                 string typeName = reader.GetString();
+                
 
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.PropertyName) throw new JsonException("Unexpected error value.");
+
+                propertyName = reader.GetString();
+                if ("docs" != propertyName) throw new JsonException("Unexpected error value.");
+
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.StartArray) throw new JsonException("Unexpected error value.");
+
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.String) throw new JsonException("Unexpected error value.");
+
+                again:
+                reader.Read();
+                if (reader.TokenType == JsonTokenType.String)
+                {
+                    if (reader.TokenType != JsonTokenType.String) throw new JsonException("Unexpected error value.");
+                    goto again;
+                }
+
+                if (reader.TokenType != JsonTokenType.EndArray) throw new JsonException("Unexpected error value.");
+                
 
                 reader.Read();
                 if (reader.TokenType != JsonTokenType.PropertyName) throw new JsonException("Unexpected error value.");

--- a/Solnet.Anchor/Converters/IIdlTypeDefinitionTyConverter.cs
+++ b/Solnet.Anchor/Converters/IIdlTypeDefinitionTyConverter.cs
@@ -34,34 +34,30 @@ namespace Solnet.Anchor.Converters
 
                 string typeName = reader.GetString();
                 
-
                 reader.Read();
                 if (reader.TokenType != JsonTokenType.PropertyName) throw new JsonException("Unexpected error value.");
 
                 propertyName = reader.GetString();
-                if ("docs" != propertyName) throw new JsonException("Unexpected error value.");
-
-                reader.Read();
-                if (reader.TokenType != JsonTokenType.StartArray) throw new JsonException("Unexpected error value.");
-
-                reader.Read();
-                if (reader.TokenType != JsonTokenType.String) throw new JsonException("Unexpected error value.");
-
-                again:
-                reader.Read();
-                if (reader.TokenType == JsonTokenType.String)
+                if (propertyName == "docs")
                 {
+                    reader.Read();
+                    if (reader.TokenType != JsonTokenType.StartArray) throw new JsonException("Unexpected error value.");
+
+                    reader.Read();
                     if (reader.TokenType != JsonTokenType.String) throw new JsonException("Unexpected error value.");
-                    goto again;
+
+                    again:
+                    reader.Read();
+                    if (reader.TokenType == JsonTokenType.String) goto again;
+
+                    if (reader.TokenType != JsonTokenType.EndArray) throw new JsonException("Unexpected error value.");
+
+                    reader.Read();
+                    if (reader.TokenType != JsonTokenType.PropertyName) throw new JsonException("Unexpected error value.");
+
+                    propertyName = reader.GetString();
                 }
 
-                if (reader.TokenType != JsonTokenType.EndArray) throw new JsonException("Unexpected error value.");
-                
-
-                reader.Read();
-                if (reader.TokenType != JsonTokenType.PropertyName) throw new JsonException("Unexpected error value.");
-
-                propertyName = reader.GetString();
                 if ("type" != propertyName) throw new JsonException("Unexpected error value.");
 
                 reader.Read();


### PR DESCRIPTION
**Issue:**
From issue #22, generating code from an anchor idl which contains a docs element such as `"docs":[ "String" ]` will crash the code when executed.

**Solution:**
These lines of code will be able to look at the docs section without issue, however these changes do not generate code with the contents of docs. 

**Previously:**
![image](https://user-images.githubusercontent.com/29475587/236198777-c830fcbb-adb2-450f-b79f-7f742ecd74df.png)

**Next steps:**
To add code to generate code using the docs from the idl for other users, this I have zero clue how to do, plus isn't something I need.

**Other notes:**
This is my first time forking and making a PR, hopefully I haven't messed anything up.